### PR TITLE
* Fix numlock key display and effect do not correspond.

### DIFF
--- a/ukui-greeter/greeter/greeterwindow.cpp
+++ b/ukui-greeter/greeter/greeterwindow.cpp
@@ -258,7 +258,6 @@ void GreeterWindow::resizeEvent(QResizeEvent *event)
     QSize size = event->size();
     //重新计算缩放比例
     scale = QString::number(size.width() / 1920.0, 'f', 1).toFloat();
-    scale = scale > 0.5 ? scale : (width() >= 800 ? 0.5 : scale);
     
     if(scale > 1)
         scale = 1;

--- a/ukui-greeter/greeter/greeterwindow.cpp
+++ b/ukui-greeter/greeter/greeterwindow.cpp
@@ -163,6 +163,7 @@ void GreeterWindow::initUI()
     m_languageLB->setFont(QFont("Ubuntu", 16));
     m_languageLB->setFixedHeight(48);
     m_languageLB->setCursor(Qt::PointingHandCursor);
+    m_languageLB->installEventFilter(this);
     LanguagesVector defaultLang = getLanguages();
     if(defaultLang.count()>0){
         m_languageLB->setText(defaultLang.at(0).name);
@@ -223,6 +224,8 @@ void GreeterWindow::initUI()
         QString lastLoginUser = Configuration::instance()->getLastLoginUser();
         m_userWnd->setCurrentUser(lastLoginUser);
     }
+
+    setWindowOpacity(0.5);
 }
 
 void GreeterWindow::setUserWindowVisible(bool visible)
@@ -330,9 +333,15 @@ bool GreeterWindow::eventFilter(QObject *obj, QEvent *event)
 {
     if(event->type() == QEvent::MouseButtonPress){
         if(m_sessionWnd && m_sessionWnd->isVisible())
-            m_sessionWnd->hide();
+        {
+            m_sessionWnd->close();
+            m_sessionWnd = nullptr;
+        }
         if(m_languageWnd && m_languageWnd->isVisible())
-            m_languageWnd->hide();
+        {
+            m_languageWnd->close();
+            m_languageWnd = nullptr;
+        }
     }
     return false;
 }
@@ -568,13 +577,13 @@ void GreeterWindow::showLanguageWnd()
     }
     m_languageHasChanged = true;
     if(m_languageWnd->isVisible()){
-        m_languageWnd->hide();
+        m_languageWnd->close();
+        m_languageWnd = nullptr;
         setFocus();
     }
     else{
         m_languageWnd->show();
         m_languageWnd->setFocus();
-        m_languageWnd->setCurrentLanguage(m_greeter->lang());
         m_languageWnd->move(m_languageLB->x(),m_languageLB->y()-m_languageWnd->height() - 3);
     }
 }
@@ -637,6 +646,10 @@ void GreeterWindow::onLanguageChanged(const Language &language)
     {
         m_userWnd->setFocus();
     }
+    if(m_languageWnd){
+        m_languageWnd->close();
+        m_languageWnd = nullptr;
+    }
 }
 
 void GreeterWindow::showSessionWnd()
@@ -650,13 +663,13 @@ void GreeterWindow::showSessionWnd()
     m_sessionHasChanged = true;
 
     if(m_sessionWnd->isVisible()){
-        m_sessionWnd->hide();
+        m_sessionWnd->close();
+        m_sessionWnd = nullptr;
         setFocus();
     }
     else{
         m_sessionWnd->move(m_languageLB->x(),m_languageLB->y()-m_sessionWnd->height() - 3);
         m_sessionWnd->show();
-        m_sessionWnd->setCurrentSession(m_greeter->session());
         m_sessionWnd->setFocus();
     }
 }
@@ -703,6 +716,11 @@ void GreeterWindow::onSessionChanged(const QString &session)
     if(m_userWnd && !m_userWnd->isHidden())
     {
         m_userWnd->setFocus();
+    }
+
+    if(m_sessionWnd){
+        m_sessionWnd->close();
+        m_sessionWnd = nullptr;
     }
 }
 

--- a/ukui-greeter/greeter/languagewidget.cpp
+++ b/ukui-greeter/greeter/languagewidget.cpp
@@ -90,7 +90,7 @@ bool LanguageWidget::eventFilter(QObject *obj, QEvent *event)
     //失去焦点时隐藏窗口
     if(event->type() == 23)
     {
-        hide();
+        close();
     }
     return false;
 }

--- a/ukui-greeter/greeter/loginwindow.cpp
+++ b/ukui-greeter/greeter/loginwindow.cpp
@@ -196,6 +196,9 @@ void LoginWindow::setChildrenGeometry()
 
     // 密码框和提示信息显示位置
 
+    if(scale < 0.5)
+        setFixedWidth(300);
+
     m_passwdWidget->setGeometry(0, 0, width(), 150);
     m_passwordEdit->setGeometry((m_passwdWidget->width() - 300)/2, 0, 300, 34);
     m_messageLabel->setGeometry((m_passwdWidget->width() - 600)/2,

--- a/ukui-greeter/greeter/main.cpp
+++ b/ukui-greeter/greeter/main.cpp
@@ -131,9 +131,14 @@ int main(int argc, char *argv[])
     //设置鼠标指针样式
     XDefineCursor(QX11Info::display(), QX11Info::appRootWindow(), XCreateFontCursor(QX11Info::display(), XC_arrow));
 
-    //默认打开numlock
+    //默认打开numlock,以及关闭caps lock,需要设置两次，否则灯和效果可能不一致，原因不知
     unsigned int num_mask = XkbKeysymToModifiers (QX11Info::display(), XK_Num_Lock);
+    XkbLockModifiers (QX11Info::display(), XkbUseCoreKbd, num_mask, 0);
     XkbLockModifiers (QX11Info::display(), XkbUseCoreKbd, num_mask, num_mask);
+  
+    unsigned int caps_mask = XkbKeysymToModifiers (QX11Info::display(), XK_Caps_Lock); 
+    XkbLockModifiers (QX11Info::display(), XkbUseCoreKbd, num_mask, caps_mask);
+    XkbLockModifiers (QX11Info::display(), XkbUseCoreKbd, num_mask, 0);
 
     //等待显示器准备完毕
     /*waitMonitorsReady();

--- a/ukui-greeter/greeter/main.cpp
+++ b/ukui-greeter/greeter/main.cpp
@@ -31,6 +31,8 @@
 #include <QProcess>
 #include <QScreen>
 #include <X11/Xlib.h>
+#include <X11/XKBlib.h>
+#include <X11/keysym.h>
 #include <X11/cursorfont.h>
 #include <X11/extensions/Xrandr.h>
 #include "globalv.h"
@@ -129,6 +131,9 @@ int main(int argc, char *argv[])
     //设置鼠标指针样式
     XDefineCursor(QX11Info::display(), QX11Info::appRootWindow(), XCreateFontCursor(QX11Info::display(), XC_arrow));
 
+    //默认打开numlock
+    unsigned int num_mask = XkbKeysymToModifiers (QX11Info::display(), XK_Num_Lock);
+    XkbLockModifiers (QX11Info::display(), XkbUseCoreKbd, num_mask, num_mask);
 
     //等待显示器准备完毕
     /*waitMonitorsReady();

--- a/ukui-greeter/greeter/sessionwindow.cpp
+++ b/ukui-greeter/greeter/sessionwindow.cpp
@@ -108,7 +108,7 @@ bool SessionWindow::eventFilter(QObject *obj, QEvent *event)
     //失去焦点时隐藏窗口
     if(event->type() == 23)
     {
-        hide();
+        close();
     }
     return false;
 }

--- a/ukui-greeter/greeter/userentry.cpp
+++ b/ukui-greeter/greeter/userentry.cpp
@@ -74,6 +74,7 @@ void UserEntry::paintEvent(QPaintEvent *event)
 
 void UserEntry::resizeEvent(QResizeEvent *)
 {
+
     setResize();
 }
 
@@ -127,16 +128,18 @@ void UserEntry::setFace(const QString &facePath)
         m_faceLabel->setStyleSheet(SheetStyle);
         userface = scaledPixmap(CENTER_IMG_WIDTH, CENTER_IMG_WIDTH, m_face);
         userface =  PixmapToRound(userface, CENTER_IMG_WIDTH/2);
+        m_faceLabel->setPixmap(PixmapToOpacity(userface,1));
     }
     else{
         const QString SheetStyle = QString("border-radius: %1px;  border:0px   solid white;").arg(IMG_WIDTH/2);
         m_faceLabel->setStyleSheet(SheetStyle);
         userface = scaledPixmap(IMG_WIDTH, IMG_WIDTH, m_face);
         userface =  PixmapToRound(userface, IMG_WIDTH/2);
+        m_faceLabel->setPixmap(PixmapToOpacity(userface,0.8));
     }
 
     m_faceLabel->setAlignment(Qt::AlignCenter);
-    m_faceLabel->setPixmap(userface);
+
 
 }
 
@@ -178,37 +181,57 @@ void UserEntry::setEnterEvent(bool isEnter)
     if(id == selectedId)
         return;
 
-    QRect faceRect,nameRect,loginRect;
+//    QRect faceRect,nameRect,loginRect;
 
-    const QString SheetStyle = QString("border-radius: %1px;  border:0px   solid white;").arg(width()/2);
-    m_faceLabel->setStyleSheet(SheetStyle);
-    faceRect.setRect(0, 0, width(), width());
-    userface = scaledPixmap(width(), width(), m_face);
-    userface =  PixmapToRound(userface, width()/2);
-    m_faceLabel->setGeometry(faceRect);
-    m_faceLabel->move((width() - m_faceLabel->width())/2,m_faceLabel->y());
+//    const QString SheetStyle = QString("border-radius: %1px;  border:0px   solid white;").arg(width()/2);
+//    m_faceLabel->setStyleSheet(SheetStyle);
+//    faceRect.setRect(0, 0, width(), width());
+//    userface = scaledPixmap(width(), width(), m_face);
+//    userface =  PixmapToRound(userface, width()/2);
+//    m_faceLabel->setGeom/*etry(faceRect);
+//    m_faceLabel->move((width() - m_faceLabel->width())*//2,m_faceLabel->y());
 
-    m_faceLabel->setPixmap(userface);
+//    m_faceLabel->setPixmap(userface);
 
-    m_loginLabel->setGeometry(m_faceLabel->x() + m_faceLabel->width() - 24,m_faceLabel->y(),24,24);
+//    m_loginLabel->setGeometry(m_faceLabel->x() + m_faceLabel->width() - 24,m_faceLabel->y(),24,24);
 
-    if(isEnter)
-    {
-        QFont font = m_nameLabel->font();
-        font.setPixelSize(16);
-        m_nameLabel->setFont(font);
-        m_nameLabel->adjustSize();
-	//距离头像保持25距离
-        m_nameLabel->move((width() - m_nameLabel->width())/2,m_faceLabel->y() + m_faceLabel->height() + 25);
-    }
-    else
-    {
-        QFont font = m_nameLabel->font();
-        font.setPixelSize(14);
-        m_nameLabel->setFont(font);
-        m_nameLabel->adjustSize();
-        m_nameLabel->move((width() - m_nameLabel->width())/2,m_faceLabel->y() + m_faceLabel->height() + 32);
-    }
+//    if(isEnter)
+//    {
+//        QFont font = m_nameLabel->font();
+//        font.setPixelSize(16);
+//        m_nameLabel->setFont(font);
+//        m_nameLabel->adjustSize();
+//	//距离头像保持25距离
+//        m_nameLabel->move((width() - m_nameLabel->width())/2,m_faceLabel->y() + m_faceLabel->height() + 25);
+//    }
+//    else
+//    {
+//        QFont font = m_nameLabel->font();
+//        font.setPixelSize(14);
+//        m_nameLabel->setFont(font);
+//        m_nameLabel->adjustSize();
+//        m_nameLabel->move((width() - m_nameLabel->width())/2,m_faceLabel->y() + m_faceLabel->height() + 32);
+//    }
+
+      userface = scaledPixmap(width(), width(), m_face);
+      userface =  PixmapToRound(userface, width()/2);
+      if(isEnter)
+          m_faceLabel->setPixmap(PixmapToOpacity(userface,1));
+      else
+          m_faceLabel->setPixmap(PixmapToOpacity(userface,0.8));
+}
+
+//返回一张带有透明度的图片,0<=val<=1
+QPixmap UserEntry::PixmapToOpacity(const QPixmap src, double val)
+{
+    QPixmap temp(src.size());
+    temp.fill(Qt::transparent);
+    QPainter p(&temp);
+    p.setCompositionMode(QPainter::CompositionMode_Source);
+    p.drawPixmap(0, 0, src);
+    p.setCompositionMode(QPainter::CompositionMode_DestinationIn);
+    p.fillRect(temp.rect(), QColor(0, 0, 0, val*255));
+    return temp;
 }
 
 void UserEntry::setResize()
@@ -223,8 +246,6 @@ void UserEntry::setResize()
     m_faceLabel->setGeometry(faceRect);
     m_faceLabel->move((width() - m_faceLabel->width())/2,m_faceLabel->y());
 
-    m_faceLabel->setPixmap(userface);
-
     m_loginLabel->setGeometry(m_faceLabel->x() + m_faceLabel->width() - 24,m_faceLabel->y(),24,24);
 
     if(id == selectedId)
@@ -235,6 +256,8 @@ void UserEntry::setResize()
         m_nameLabel->adjustSize();
 	//距离头像保持25距离
         m_nameLabel->move((width() - m_nameLabel->width())/2,m_faceLabel->y() + m_faceLabel->height() + 25);
+        m_faceLabel->setPixmap(PixmapToOpacity(userface,1));
+
     }
     else
     {
@@ -244,6 +267,8 @@ void UserEntry::setResize()
         m_nameLabel->adjustSize();
 	//当前头像，用户名距离头像保持32距离
         m_nameLabel->move((width() - m_nameLabel->width())/2,m_faceLabel->y() + m_faceLabel->height() + 32);
+        m_faceLabel->setPixmap(PixmapToOpacity(userface,0.8));
+
     }
 }
 

--- a/ukui-greeter/greeter/userentry.h
+++ b/ukui-greeter/greeter/userentry.h
@@ -54,7 +54,6 @@ public:
     void setResize();
     void setEnterEvent(bool isEnter);
     void setMoveSize();
-    QPixmap PixmapToRound(const QPixmap &src, int radius);
 
 protected:
     bool eventFilter(QObject *obj, QEvent *event);
@@ -64,6 +63,8 @@ protected:
 private:
     void onClicked();
     void initUI();
+    QPixmap PixmapToRound(const QPixmap &src, int radius);
+    QPixmap PixmapToOpacity(const QPixmap src , double val);
 
 
 signals:

--- a/ukui-greeter/greeter/usersview.cpp
+++ b/ukui-greeter/greeter/usersview.cpp
@@ -81,7 +81,7 @@ void UsersView::initUI()
     prevArrow->setGeometry(LEFT_ARROW_X,0,CENTER_ENTRY_WIDTH/2,CENTER_ENTRY_HEIGHT);
     prevArrow->hide();
     connect(prevArrow,&QPushButton::clicked,this,[this](){
-        leftKeyPressed();
+        leftKeyPressed(true);
     });
 
     nextArrow = new QPushButton(this);
@@ -91,7 +91,7 @@ void UsersView::initUI()
     nextArrow->setGeometry(RIGHT_ARROW_X,0,CENTER_ENTRY_WIDTH/2,CENTER_ENTRY_HEIGHT);
     nextArrow->hide();
     connect(nextArrow,&QPushButton::clicked,this,[this](){
-        rightKeyPressed();
+        rightKeyPressed(true);
     });
 
 }
@@ -103,24 +103,24 @@ bool UsersView::eventFilter(QObject *obj, QEvent *event)
         for(int i=0;i<userlist.count();i++){
             if(obj == userlist.at(i)){
                     //添加定时器，防止点击过快。
-                    int interval = mouseClickLast.msecsTo(QTime::currentTime());
-                    if(interval < 300 && interval > -300)
-                        return false;
+//                    int interval = mouseClickLast.msecsTo(QTime::currentTime());
+//                    if(interval < 100 && interval > -100)
+//                        return false;
                     mouseClickLast = QTime::currentTime();
 
                     if(i == currentUser - 1){
-                        leftKeyPressed();
+                        leftKeyPressed(true);
                     }
                     else if(i == currentUser -2){
-                        leftKeyPressed();
-                        leftKeyPressed();
+                        leftKeyPressed(false);
+                        leftKeyPressed(true);
                     }
                     else if(i == currentUser + 1){
-                        rightKeyPressed();
+                        rightKeyPressed(true);
                     }
                     else if(i == currentUser + 2){
-                        rightKeyPressed();
-                        rightKeyPressed();
+                        rightKeyPressed(false);
+                        rightKeyPressed(true);
                     }
             }
         }
@@ -129,15 +129,14 @@ bool UsersView::eventFilter(QObject *obj, QEvent *event)
     if(event->type() == QEvent::Enter){
         for(int i=0;i<userlist.count();i++){
             if(obj == userlist.at(i)){
-                if(i == currentUser - 2)
-                    userlist.at(i)->setGeometry(ITEM1_X,ITEM_CENTER_Y,CENTER_ENTRY_WIDTH,CENTER_ENTRY_HEIGHT);
-                else if(i == currentUser - 1)
-                    userlist.at(i)->setGeometry(ITEM2_X,ITEM_CENTER_Y,CENTER_ENTRY_WIDTH,CENTER_ENTRY_HEIGHT);
-                else if(i == currentUser + 1)
-                    userlist.at(i)->setGeometry(ITEM4_X,ITEM_CENTER_Y,CENTER_ENTRY_WIDTH,CENTER_ENTRY_HEIGHT);
-                else if(i == currentUser + 2)
-                    userlist.at(i)->setGeometry(ITEM5_X,ITEM_CENTER_Y,CENTER_ENTRY_WIDTH,CENTER_ENTRY_HEIGHT);
-
+//                if(i == currentUser - 2)
+//                    userlist.at(i)->setGeometry(ITEM1_X,ITEM_CENTER_Y,CENTER_ENTRY_WIDTH,CENTER_ENTRY_HEIGHT);
+//                else if(i == currentUser - 1)
+//                    userlist.at(i)->setGeometry(ITEM2_X,ITEM_CENTER_Y,CENTER_ENTRY_WIDTH,CENTER_ENTRY_HEIGHT);
+//                else if(i == currentUser + 1)
+//                    userlist.at(i)->setGeometry(ITEM4_X,ITEM_CENTER_Y,CENTER_ENTRY_WIDTH,CENTER_ENTRY_HEIGHT);
+//                else if(i == currentUser + 2)
+//                    userlist.at(i)->setGeometry(ITEM5_X,ITEM_CENTER_Y,CENTER_ENTRY_WIDTH,CENTER_ENTRY_HEIGHT);
                 userlist.at(i)->setEnterEvent(true);
             }
         }
@@ -146,15 +145,14 @@ bool UsersView::eventFilter(QObject *obj, QEvent *event)
     if(event->type() == QEvent::Leave){
         for(int i=0;i<userlist.count();i++){
             if(obj == userlist.at(i)){
-                if(i == currentUser - 2)
-                    userlist.at(i)->setGeometry(ITEM1_X,ITEM_Y,ENTRY_WIDTH,ENTRY_HEIGHT);
-                else if(i == currentUser - 1)
-                    userlist.at(i)->setGeometry(ITEM2_X,ITEM_Y,ENTRY_WIDTH,ENTRY_HEIGHT);
-                else if(i == currentUser + 1)
-                    userlist.at(i)->setGeometry(ITEM4_X,ITEM_Y,ENTRY_WIDTH,ENTRY_HEIGHT);
-                else if(i == currentUser + 2)
-                    userlist.at(i)->setGeometry(ITEM5_X,ITEM_Y,ENTRY_WIDTH,ENTRY_HEIGHT);
-
+//                if(i == currentUser - 2)
+//                    userlist.at(i)->setGeometry(ITEM1_X,ITEM_Y,ENTRY_WIDTH,ENTRY_HEIGHT);
+//                else if(i == currentUser - 1)
+//                    userlist.at(i)->setGeometry(ITEM2_X,ITEM_Y,ENTRY_WIDTH,ENTRY_HEIGHT);
+//                else if(i == currentUser + 1)
+//                    userlist.at(i)->setGeometry(ITEM4_X,ITEM_Y,ENTRY_WIDTH,ENTRY_HEIGHT);
+//                else if(i == currentUser + 2)
+//                    userlist.at(i)->setGeometry(ITEM5_X,ITEM_Y,ENTRY_WIDTH,ENTRY_HEIGHT);
                 userlist.at(i)->setEnterEvent(false);
             }
         }
@@ -198,14 +196,14 @@ void UsersView::onGlobalKeyRelease(const QString &key)
     lasttime = QTime::currentTime();
     if(key.compare("right",Qt::CaseInsensitive)==0)
     {
-        rightKeyPressed();
+        rightKeyPressed(true);
     }
     else if (key.compare("left",Qt::CaseInsensitive)==0) {
-        leftKeyPressed();
+        leftKeyPressed(true);
     }
 }
 
-void UsersView::leftKeyPressed()
+void UsersView::leftKeyPressed(bool isChoosed)
 {
     if(currentUser <= 0)
        return;
@@ -227,9 +225,11 @@ void UsersView::leftKeyPressed()
             break;
     }
 
-    QModelIndex index = usersModel->index(x, 0);
-    Q_EMIT currentUserChanged(index);
-    Q_EMIT userSelected(index);
+    if(isChoosed){
+        QModelIndex index = usersModel->index(x, 0);
+        Q_EMIT currentUserChanged(index);
+        Q_EMIT userSelected(index);
+    }
 
     if(currentUser >= 3)
         prevArrow->show();
@@ -243,7 +243,7 @@ void UsersView::leftKeyPressed()
 
 }
 
-void UsersView::rightKeyPressed()
+void UsersView::rightKeyPressed(bool isChoosed)
 {
     if(currentUser >= userlist.count() - 1)
         return ;
@@ -264,9 +264,11 @@ void UsersView::rightKeyPressed()
            break;
    }
 
-   QModelIndex index = usersModel->index(x, 0);
-   Q_EMIT currentUserChanged(index);
-   Q_EMIT userSelected(index);
+   if(isChoosed){
+       QModelIndex index = usersModel->index(x, 0);
+       Q_EMIT currentUserChanged(index);
+       Q_EMIT userSelected(index);
+   }
 
    if(currentUser >= 3)
        prevArrow->show();
@@ -505,7 +507,7 @@ void UsersView::rightToRight()
 void UsersView::moveAnimation(UserEntry *entry, QRect preRect, QRect nextRect)
 {
     QPropertyAnimation *pScaleAnimation = new QPropertyAnimation(entry, "geometry");
-    pScaleAnimation->setDuration(300);
+    pScaleAnimation->setDuration(200);
     pScaleAnimation->setStartValue(preRect);
     pScaleAnimation->setEndValue(nextRect);
     pScaleAnimation->setEasingCurve(QEasingCurve::InOutQuad);

--- a/ukui-greeter/greeter/usersview.cpp
+++ b/ukui-greeter/greeter/usersview.cpp
@@ -52,8 +52,7 @@ UsersView::UsersView(QWidget *parent) :
 {
     QSize size = QApplication::primaryScreen()->size();
     scale = QString::number(size.width() / 1920.0, 'f', 1).toFloat();
-    scale = scale > 0.5 ? scale : (width() >= 800 ? 0.5 : scale);
-	
+
     if(scale > 1)
 	    scale = 1;
 // CENTER_ENTRY_WIDTH*5 +4* (CENTER_ENTRY_WIDTH - ENTRY_WIDTH*) +CENTER_ENTRY_WIDTH 
@@ -77,7 +76,7 @@ void UsersView::initUI()
     prevArrow = new QPushButton(this);
     prevArrow->setObjectName("prevArrow");
     prevArrow->setIcon(QIcon(":/resource/prev.png"));
-    prevArrow->setIconSize(QSize(64,64));
+    prevArrow->setIconSize(QSize(64*scale,64*scale));
     prevArrow->setGeometry(LEFT_ARROW_X,0,CENTER_ENTRY_WIDTH/2,CENTER_ENTRY_HEIGHT);
     prevArrow->hide();
     connect(prevArrow,&QPushButton::clicked,this,[this](){
@@ -87,7 +86,7 @@ void UsersView::initUI()
     nextArrow = new QPushButton(this);
     nextArrow->setObjectName("nextArrow");
     nextArrow->setIcon(QIcon(":/resource/next.png"));
-    nextArrow->setIconSize(QSize(64,64));
+    nextArrow->setIconSize(QSize(64*scale,64*scale));
     nextArrow->setGeometry(RIGHT_ARROW_X,0,CENTER_ENTRY_WIDTH/2,CENTER_ENTRY_HEIGHT);
     nextArrow->hide();
     connect(nextArrow,&QPushButton::clicked,this,[this](){

--- a/ukui-greeter/greeter/usersview.h
+++ b/ukui-greeter/greeter/usersview.h
@@ -68,8 +68,11 @@ private:
     void centerToleft();
     void centerToRight();
     void moveAnimation(UserEntry *entry,QRect preRect,QRect nextRect);
-    void leftKeyPressed();
-    void rightKeyPressed();
+    /*左方向建按下，isChoosed代表下个用户是否为选中用户，如果不是，则不触发用户改变
+        信号，只进行头像的动画效果。
+    */
+    void leftKeyPressed(bool isChoosed);
+    void rightKeyPressed(bool isChoosed);
 
 private:
     QAbstractListModel *usersModel;


### PR DESCRIPTION
* 优化登录界面切换用户时头像显示和背景切换代码，减少不必要的操作。
* 修改用户未被选中时，用户头像透明度为0.8，选中用户头像透明度为1.
* 去掉鼠标移动到用户头像上时，用户头像变大效果，改为将头像透明度设置为1.
* 登录启动时默认打开numlock键，解决切换用户时，numlock灯为亮，但实际上数字键盘不可用的问题。